### PR TITLE
Fix: remove decodeUri 

### DIFF
--- a/src/httpsnippet.ts
+++ b/src/httpsnippet.ts
@@ -312,12 +312,10 @@ export class HTTPSnippet {
       ...uriObj,
     }); //?
 
-    const decodedFullUrl = decodeURIComponent(fullUrl);
-
     return {
       ...request,
       allHeaders,
-      fullUrl: decodedFullUrl,
+      fullUrl,
       url,
       uriObj,
     };


### PR DESCRIPTION
Reverting change https://github.com/hoppscotch/httpsnippet/commit/0af313afc808f93e3af1728227f64b4bff6a3997

This change was causing an issue where urls with encoded chars was been decoded

See: https://github.com/hoppscotch/hoppscotch/issues/4769