### PR TITLE
fix : invalid query string when duplicate query param keys are provided

### DIFF
--- a/src/helpers/query-params.ts
+++ b/src/helpers/query-params.ts
@@ -1,0 +1,18 @@
+import { ReducedHelperObject } from './reducer';
+
+/**
+ * Given a query params object return a flattened query string.
+ */
+export const getQueryString = (queryObj: ReducedHelperObject): string => {
+  const params = new URLSearchParams();
+
+  Object.entries(queryObj).forEach(([key, value]) => {
+    if (Array.isArray(value)) {
+      value.forEach(v => params.append(key, v));
+    } else {
+      params.append(key, value);
+    }
+  });
+
+  return params.toString();
+};

--- a/src/httpsnippet.test.ts
+++ b/src/httpsnippet.test.ts
@@ -1,4 +1,5 @@
 import { mimetypes } from './fixtures/mimetypes';
+import full from './fixtures/requests/full.json';
 import headers from './fixtures/requests/headers.json';
 import query from './fixtures/requests/query.json';
 import short from './fixtures/requests/short.json';
@@ -215,6 +216,34 @@ describe('hTTPSnippet', () => {
 
         expect(request.fullUrl).toBe('http://mockbin.com/har?foo=bar&foo=baz&baz=abc&key=value');
       });
+    });
+  });
+
+  describe('queryObj', () => {
+    it('should build queryObj with arrays for duplicate keys', () => {
+      const snippet = new HTTPSnippet(full as Request);
+      const request = snippet.requests[0];
+
+      expect(request.queryObj).toMatchObject({
+        key: 'value',
+        foo: ['bar', 'baz'],
+        baz: 'abc',
+      });
+    });
+
+    it('should not include array-indexed query keys like foo[0]', () => {
+      const snippet = new HTTPSnippet(full as Request);
+      const curl = snippet.convert('shell', 'curl');
+
+      expect(curl).not.toMatch(/foo\[\d+\]=/);
+    });
+
+    it('should handle empty queryString array gracefully', () => {
+      const snippet = new HTTPSnippet(short as Request);
+
+      const curl = snippet.convert('shell', 'curl');
+
+      expect(curl).toContain('--url http://mockbin.com/har');
     });
   });
 });

--- a/src/httpsnippet.ts
+++ b/src/httpsnippet.ts
@@ -7,6 +7,7 @@ import { format as urlFormat, parse as urlParse, UrlWithParsedQuery } from 'url'
 
 import { formDataIterator, isBlob } from './helpers/form-data';
 import { getHeaderName } from './helpers/headers';
+import { getQueryString } from './helpers/query-params';
 import { ReducedHelperObject, reducer } from './helpers/reducer';
 import { ClientId, TargetId, targets } from './targets/targets';
 
@@ -291,7 +292,7 @@ export class HTTPSnippet {
     }; //?
 
     // reset uriObj values for a clean url
-    const search = queryStringify(request.queryObj);
+    const search = getQueryString(request.queryObj);
 
     const uriObj = {
       ...urlWithParsedQuery,


### PR DESCRIPTION
This is a fix to the issue [https://github.com/hoppscotch/hoppscotch/issues/5001](url) in Hoppscotch, where the curl generated is invalid whenever there are duplicate query params.